### PR TITLE
fix: autocomplete and error refinements

### DIFF
--- a/src/DarkId.Papyrus.LanguageService/Program/AntlrExtensions.cs
+++ b/src/DarkId.Papyrus.LanguageService/Program/AntlrExtensions.cs
@@ -54,6 +54,15 @@ namespace DarkId.Papyrus.LanguageService.Program
 
         public static Range GetRange(this CommonTree node, ITokenStream tokenStream, IReadOnlyScriptText scriptText)
         {
+            if (node is CommonErrorNode errorNode)
+            {
+                return new Range()
+                {
+                    Start = scriptText.PositionAt(((CommonToken)tokenStream.Get(errorNode.start.TokenIndex)).StartIndex),
+                    End = scriptText.PositionAt(((CommonToken)tokenStream.Get(errorNode.stop.TokenIndex)).StopIndex + 1)
+                };
+            }
+
             if (node.TokenStartIndex == -1 || node.TokenStopIndex == -1)
             {
                 return Range.Empty;

--- a/src/DarkId.Papyrus.LanguageService/Program/ScriptFile.cs
+++ b/src/DarkId.Papyrus.LanguageService/Program/ScriptFile.cs
@@ -130,7 +130,10 @@ namespace DarkId.Papyrus.LanguageService.Program
                             var typeWalker = new TypeWalker(this, type, _logger);
                             typeWalker.OnError((s, e) =>
                             {
-                                diagnostics.Add(e.ToDiagnostic());
+                                if (!e.ErrorText.StartsWith("mismatched tree node"))
+                                {
+                                    diagnostics.Add(e.ToDiagnostic());
+                                }
                             });
 
                             try

--- a/src/DarkId.Papyrus.LanguageService/Program/SemanticExtensions.cs
+++ b/src/DarkId.Papyrus.LanguageService/Program/SemanticExtensions.cs
@@ -4,6 +4,8 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Antlr.Runtime;
+using Antlr.Runtime.Tree;
 using DarkId.Papyrus.Common;
 using DarkId.Papyrus.LanguageService.Program.Symbols;
 using DarkId.Papyrus.LanguageService.Program.Syntax;
@@ -271,6 +273,22 @@ namespace DarkId.Papyrus.LanguageService.Program
                 {
                     return accessExpression.GetReferencableSymbolsForMemberAccess();
                 }
+            }
+
+            if (node is IdentifierNode &&
+                (node.Parent is DeclareStatementNode || node.Parent is FunctionParameterNode))
+            {
+                return Enumerable.Empty<PapyrusSymbol>();
+            }
+
+            if (!(node is ScriptHeaderNode) && node is ITypedIdentifiable typed && typed.TypeIdentifier.Text != string.Empty)
+            {
+                return Enumerable.Empty<PapyrusSymbol>();
+            }
+            
+            if (node.CompilerNode is CommonErrorNode)
+            {
+                return Enumerable.Empty<PapyrusSymbol>();
             }
 
             var symbolsInScope = GetSymbolsInScope(node, node is ScriptHeaderNode || node is ScriptNode);

--- a/src/DarkId.Papyrus.LanguageService/Program/Syntax/NodeBinder.cs
+++ b/src/DarkId.Papyrus.LanguageService/Program/Syntax/NodeBinder.cs
@@ -390,9 +390,9 @@ namespace DarkId.Papyrus.LanguageService.Program.Syntax
             });
         }
 
-#endregion
+        #endregion
 
-#region Statements
+        #region Statements
 
         private SyntaxNode BindStatement(IStatementBlock parent, Scanner<CommonTree> parentChildren)
         {
@@ -544,9 +544,9 @@ namespace DarkId.Papyrus.LanguageService.Program.Syntax
             });
         }
 
-#endregion
+        #endregion
 
-#region Expressions
+        #region Expressions
 
         private ExpressionNode BindExpression(SyntaxNode parent, Scanner<CommonTree> parentChildren)
         {
@@ -793,17 +793,23 @@ namespace DarkId.Papyrus.LanguageService.Program.Syntax
         private static bool ShouldContractNodeEnd(SyntaxNode node)
         {
             return node is IStatementBlock
-                || node is PropertyHeaderNode;
+                || node is PropertyHeaderNode
+                || node is DeclareStatementNode;
         }
 
-#endregion
-        
+        #endregion
+
         private T CreateNode<T>(SyntaxNode parent, Scanner<CommonTree> parentChildren, Action<T, Scanner<CommonTree>> bindAction = null)
             where T : SyntaxNode
         {
             var compilerNode = parentChildren.Current;
-
             var range = compilerNode.GetRange(_tokenStream, _text);
+
+            if (compilerNode is CommonErrorNode errorNode)
+            {
+                _diagnostics.Add(errorNode.trappedException.ToDiagnostic(range));
+            }
+
             var text = _text.GetTextInRange(range).TrimEnd();
 
             var node = Activator.CreateInstance<T>();

--- a/src/DarkId.Papyrus.Test/LanguageService/Program/ScriptFileTests.cs
+++ b/src/DarkId.Papyrus.Test/LanguageService/Program/ScriptFileTests.cs
@@ -17,7 +17,8 @@ namespace DarkId.Papyrus.Test.LanguageService.Program
         [TestMethod]
         public void ScriptFile_ShouldNotProduceDiagnostics()
         {
-            var allDiagnostics = Program.ScriptFiles.Values.AsParallel().AsOrdered().SelectMany(s => s.Diagnostics).ToList();
+            var allDiagnostics = Program.ScriptFiles.Values.AsParallel().AsOrdered().
+                Where(s => s.Text.Text.IndexOf(";/test:ignore-diagnostics/;") == -1).SelectMany(s => s.Diagnostics).ToList();
 
             Console.WriteLine(allDiagnostics.Select(d => d.Message).Join(",\r\n\r\n"));
 

--- a/src/DarkId.Papyrus.Test/LanguageService/Program/TestHarness/ProgramExtensions.cs
+++ b/src/DarkId.Papyrus.Test/LanguageService/Program/TestHarness/ProgramExtensions.cs
@@ -12,9 +12,16 @@ namespace DarkId.Papyrus.Test.LanguageService.Program.TestHarness
 {
     public static class ProgramExtensions
     {
-        public static Position GetTestMarker(this ScriptFile file, string marker)
+        public static Position GetTestMarker(this ScriptFile file, string marker, bool before = false)
         {
-            return file.Text.PositionAt(file.Text.Text.IndexOf($";/marker:{marker}/;"));
+            var markerComment = $";/marker:{marker}/;";
+            var markerCommentIndex = file.Text.Text.IndexOf(markerComment);
+            if (markerCommentIndex == -1)
+            {
+                return new Position();
+            }
+
+            return file.Text.PositionAt(markerCommentIndex + (before ? 0 : markerComment.Length));
         }
 
         public static void AssertAreOfKinds(this IEnumerable<PapyrusSymbol> symbols, SymbolKinds kinds)

--- a/src/DarkId.Papyrus.Test/scripts/Fallout 4/ScopeTests.psc
+++ b/src/DarkId.Papyrus.Test/scripts/Fallout 4/ScopeTests.psc
@@ -19,7 +19,7 @@ int Function ReturningIntFunction(;/marker:function-parameter-type/;int\
 
     StructA hello
 
-    StructA[] helloArray = new StructA[0]
+    StructA[] ;/marker:declaration-identifier/;helloArray = new StructA[0]
     var len = helloArray.;/marker:array-member-access/;Length
 
     ScriptObject.;/marker:global-function-call/;NativeGlobalFunction()
@@ -28,8 +28,11 @@ int Function ReturningIntFunction(;/marker:function-parameter-type/;int\
     obj.;/marker:nested-function-call/;ReturnsScriptObject().ReturnsScriptObject();
 
     var ;/marker:local-variable-name/;value = 0 as ;/marker:as-expression/;int
+    
     ;/marker:function-body/;
+    
     bool isInt = value is ;/marker:is-expression/;int
+    bool ;/marker:incomplete-declaration/;
 
     return arg
 EndFunction

--- a/src/DarkId.Papyrus.Test/scripts/Skyrim/ScopeTests.psc
+++ b/src/DarkId.Papyrus.Test/scripts/Skyrim/ScopeTests.psc
@@ -28,7 +28,10 @@ int Function ReturningIntFunction(;/marker:function-parameter-type/;int\
     obj.;/marker:nested-function-call/;ReturnsScriptObject().ReturnsScriptObject();
 
     int ;/marker:local-variable-name/;value = 0 as ;/marker:as-expression/;int
+    
     ;/marker:function-body/;
+    
+    bool ;/marker:incomplete-declaration/;
 
     return arg
 EndFunction


### PR DESCRIPTION
* No longer produce suggestions for declaration identifiers.
* Now emitting diagnostics for parser errors at their positions within the document.