### PR TITLE
mod manager support

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,7 +13,9 @@
       "args": [
         "--extensionDevelopmentPath=${workspaceFolder}/src/papyrus-lang-vscode"
       ],
-      "outFiles": ["${workspaceFolder}/src/papyrus-lang-vscode/out/**/*.js"]
+      "outFiles": [
+        "${workspaceFolder}/src/papyrus-lang-vscode/out/**/*.js"
+      ]
     },
     {
       "name": "Launch (Build and copy binaries only)",
@@ -24,7 +26,9 @@
       "args": [
         "--extensionDevelopmentPath=${workspaceFolder}/src/papyrus-lang-vscode"
       ],
-      "outFiles": ["${workspaceFolder}/src/papyrus-lang-vscode/out/**/*.js"]
+      "outFiles": [
+        "${workspaceFolder}/src/papyrus-lang-vscode/out/**/*.js"
+      ]
     },
     {
       "name": "Launch (Build extension only)",
@@ -35,7 +39,9 @@
       "args": [
         "--extensionDevelopmentPath=${workspaceFolder}/src/papyrus-lang-vscode"
       ],
-      "outFiles": ["${workspaceFolder}/src/papyrus-lang-vscode/out/**/*.js"]
+      "outFiles": [
+        "${workspaceFolder}/src/papyrus-lang-vscode/out/**/*.js"
+      ]
     },
     {
       "name": "Launch (No build)",
@@ -45,7 +51,9 @@
       "args": [
         "--extensionDevelopmentPath=${workspaceFolder}/src/papyrus-lang-vscode"
       ],
-      "outFiles": ["${workspaceFolder}/src/papyrus-lang-vscode/out/**/*.js"]
+      "outFiles": [
+        "${workspaceFolder}/src/papyrus-lang-vscode/out/**/*.js"
+      ]
     }
   ]
 }

--- a/src/papyrus-lang-vscode/package.json
+++ b/src/papyrus-lang-vscode/package.json
@@ -115,7 +115,8 @@
             "properties": {
                 "papyrus.fallout4.enabled": {
                     "default": true,
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Enable support for Fallout 4."
                 },
                 "papyrus.fallout4.creationKitIniFiles": {
                     "default": [
@@ -125,19 +126,28 @@
                     "type": "array",
                     "items": {
                         "type": "string"
-                    }
+                    },
+                    "description": "INI Files for Fallout 4 version of the Creation Kit."
                 },
                 "papyrus.fallout4.installPath": {
                     "default": "C:\\Program Files (x86)\\Steam\\steamapps\\common\\Fallout 4\\",
-                    "type": "string"
+                    "type": "string",
+                    "description": "Pathname of the directory where Fallout 4 is installed."
                 },
                 "papyrus.fallout4.ignoreDebuggerVersion": {
                     "default": false,
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Allow using old version of the debugger script extender plugin with Fallout 4."
+                },
+                "papyrus.fallout4.modDirectoryPath": {
+                    "default": "",
+                    "type": "string",
+                    "description": "If you want to use a mod manager to manage the debugger plugin as a mod, set this to the path of the directory where installed mods for Fallout 4 are kept. Otherwise it will be installed in the game directory."
                 },
                 "papyrus.skyrim.enabled": {
                     "default": true,
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Enable support for Skyrim LE (\"Oldrim\"). This is not for Skyrim Special Edition!"
                 },
                 "papyrus.skyrim.creationKitIniFiles": {
                     "default": [
@@ -146,15 +156,18 @@
                     "type": "array",
                     "items": {
                         "type": "string"
-                    }
+                    },
+                    "description": "INI Files for the Oldrim version of the Creation Kit."
                 },
                 "papyrus.skyrim.installPath": {
                     "default": "C:\\Program Files (x86)\\Steam\\steamapps\\common\\Skyrim\\",
-                    "type": "string"
+                    "type": "string",
+                    "description": "Pathname of the directory where Oldrim Skyrim is installed."
                 },
                 "papyrus.skyrimSpecialEdition.enabled": {
                     "default": true,
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Enable support for Skyrim Special Edition."
                 },
                 "papyrus.skyrimSpecialEdition.creationKitIniFiles": {
                     "default": [
@@ -164,15 +177,23 @@
                     "type": "array",
                     "items": {
                         "type": "string"
-                    }
+                    },
+                    "description": "INI Files for the Skyrim Special Edition version of the Creation Kit."
                 },
                 "papyrus.skyrimSpecialEdition.installPath": {
                     "default": "C:\\Program Files (x86)\\Steam\\steamapps\\common\\Skyrim Special Edition\\",
-                    "type": "string"
+                    "type": "string",
+                    "description": "Pathname of the directory where Skyrim Special Edition is installed."
                 },
                 "papyrus.skyrimSpecialEdition.ignoreDebuggerVersion": {
                     "default": false,
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Allow using old version of the debugger script extender plugin with Skyrim Special Edition."
+                },
+                "papyrus.skyrimSpecialEdition.modDirectoryPath": {
+                    "default": "",
+                    "type": "string",
+                    "description": "If you want to use a mod manager to manage the debugger plugin as a mod, set this to the path of the directory where installed mods for Skyrim SE are kept. Otherwise it will be installed in the game directory."
                 }
             },
             "title": "Papyrus",

--- a/src/papyrus-lang-vscode/src/ExtensionConfigProvider.ts
+++ b/src/papyrus-lang-vscode/src/ExtensionConfigProvider.ts
@@ -8,6 +8,7 @@ export interface IGameConfig {
     readonly creationKitIniFiles: string[];
     readonly installPath: string;
     readonly ignoreDebuggerVersion: boolean;
+    readonly modDirectoryPath: string;
 }
 
 export interface IExtensionConfig {
@@ -35,7 +36,7 @@ export class ExtensionConfigProvider implements IExtensionConfigProvider {
         return this._config;
     }
 
-    dispose() {}
+    dispose() { }
 }
 
 export const IExtensionConfigProvider = createDecorator<IExtensionConfigProvider>('extensionConfigProvider');

--- a/src/papyrus-lang-vscode/src/debugger/DebugSupportInstallService.ts
+++ b/src/papyrus-lang-vscode/src/debugger/DebugSupportInstallService.ts
@@ -65,7 +65,7 @@ export class DebugSupportInstallService implements IDebugSupportInstallService {
 
     private async getPluginInstallPath(game: PapyrusGame, legacy = false) {
         const config = (await this._configProvider.config.pipe(take(1)).toPromise())[game];
-        const resolvedInstallPath = await resolveInstallPath(PapyrusGame.fallout4, config.installPath, this._context);
+        const resolvedInstallPath = await resolveInstallPath(game, config.installPath, this._context);
 
         if (!resolvedInstallPath) {
             return null;

--- a/src/papyrus-lang-vscode/src/features/commands/InstallDebugSupportCommand.ts
+++ b/src/papyrus-lang-vscode/src/features/commands/InstallDebugSupportCommand.ts
@@ -67,8 +67,16 @@ export class InstallDebugSupportCommand extends GameCommandBase {
             }
         );
 
+        const currentStatus = await this._installer.getInstallState(game);
+
         if (installed) {
-            window.showInformationMessage(`Papyrus debugger support for ${getDisplayNameForGame(game)} installed!`);
+            if (currentStatus === DebugSupportInstallState.installedAsMod) {
+                window.showInformationMessage(`Papyrus debugger support for ${getDisplayNameForGame(game)} installed` +
+                    " to Mod Manager Directory as mod \"Papyrus Debug Extension\"." +
+                    " Don't forget to enable it in the mod manager!");
+            } else {
+                window.showInformationMessage(`Papyrus debugger support for ${getDisplayNameForGame(game)} installed!`);
+            }
         }
     }
 }


### PR DESCRIPTION
Fixed the enum thing. Added support for installing the script extender extension as a "mod" in a way that mod managers can comprehend and enable/disable per profile. I did find that for some reason `fs.mkdirSync(dir, { recursive: true })` doesn't seem to work properly on windows so I added a workaround function.