### PR TITLE
Fix nasty bug when no workspace open

### DIFF
--- a/src/papyrus-lang-vscode/src/features/PyroTaskProvider.ts
+++ b/src/papyrus-lang-vscode/src/features/PyroTaskProvider.ts
@@ -32,6 +32,10 @@ export class PyroTaskProvider implements TaskProvider, Disposable {
 
         this._taskProviderHandle = tasks.registerTaskProvider('pyro', this);
 
+        if (!workspace.workspaceFolders) {
+            return;
+        }
+
         this._projPattern = new RelativePattern(workspace.workspaceFolders[0], "**/*.ppj");
         const fsw = this._fileWatcher = workspace.createFileSystemWatcher(this._projPattern);
         fsw.onDidChange(() => this._taskCachePromise = undefined);


### PR DESCRIPTION
Turns out it really is possible to launch vscode with no folder
open. Who knew? Well, this caused the constructor of
PyroTaskProvider to crash because it expects a workspace
folder. So we just need to make sure it doesn't expect that.