### PR TITLE
Various prep refactors

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+[*.cs]
+
+# CS4014: Task not awaited
+dotnet_diagnostic.CS4014.severity = error
+
+# CS1998: Async function does not contain await
+dotnet_diagnostic.CS1998.severity = silent

--- a/DarkId.Papyrus.sln
+++ b/DarkId.Papyrus.sln
@@ -17,7 +17,12 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Protocol Hosts", "Protocol 
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{16DCC7B6-3388-4208-8513-6BF4DFB85626}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DarkId.Papyrus.Test", "src\DarkId.Papyrus.Test\DarkId.Papyrus.Test.csproj", "{EE5047F5-E7E1-4C2D-B8C3-FE61B03B2835}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DarkId.Papyrus.Test", "src\DarkId.Papyrus.Test\DarkId.Papyrus.Test.csproj", "{EE5047F5-E7E1-4C2D-B8C3-FE61B03B2835}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{B86DCC2B-8636-452E-9DD7-CA7C98BB4153}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/DarkId.Papyrus.Common/DarkId.Papyrus.Common.csproj
+++ b/src/DarkId.Papyrus.Common/DarkId.Papyrus.Common.csproj
@@ -7,5 +7,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.0.0" />
+		<PackageReference Include="System.Interactive.Async" Version="4.1.1" />
+		<PackageReference Include="System.Linq.Async" Version="4.1.1" />
 	</ItemGroup>
 </Project>

--- a/src/DarkId.Papyrus.Common/IFileSystem.cs
+++ b/src/DarkId.Papyrus.Common/IFileSystem.cs
@@ -8,7 +8,7 @@ namespace DarkId.Papyrus.Common
     public interface IFileSystem
     {
         Task<bool> GetExists(string path);
-        Task<IEnumerable<string>> FindFiles(string rootPath, string pattern, bool recursive);
+        IAsyncEnumerable<string> FindFiles(string rootPath, string pattern, bool recursive);
         Task<Stream> OpenRead(string path);
         Task<string> GetVersion(string path);
     }

--- a/src/DarkId.Papyrus.Common/LocalFileSystem.cs
+++ b/src/DarkId.Papyrus.Common/LocalFileSystem.cs
@@ -8,27 +8,27 @@ namespace DarkId.Papyrus.Common
 {
     public class LocalFileSystem : IFileSystem
     {
-        public Task<IEnumerable<string>> FindFiles(string rootPath, string pattern, bool recursive)
+        public IAsyncEnumerable<string> FindFiles(string rootPath, string pattern, bool recursive)
         {
-            return Task.FromResult(Directory
+            return Directory
                 .EnumerateFiles(rootPath, pattern, recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly)
                 .ToArray()
-                .AsEnumerable());
+                .ToAsyncEnumerable();
         }
 
-        public Task<bool> GetExists(string path)
+        public async Task<bool> GetExists(string path)
         {
-            return Task.FromResult(Directory.Exists(path) || File.Exists(path));
+            return Directory.Exists(path) || File.Exists(path);
         }
 
-        public Task<string> GetVersion(string path)
+        public async Task<string> GetVersion(string path)
         {
-            return Task.FromResult(File.GetLastWriteTimeUtc(path).Ticks.ToString());
+            return File.GetLastWriteTimeUtc(path).Ticks.ToString();
         }
 
-        public Task<Stream> OpenRead(string path)
+        public async Task<Stream> OpenRead(string path)
         {
-            return Task.FromResult((Stream)File.OpenRead(path));
+            return (Stream)File.OpenRead(path);
         }
     }
 }

--- a/src/DarkId.Papyrus.LanguageService/DarkId.Papyrus.LanguageService.csproj
+++ b/src/DarkId.Papyrus.LanguageService/DarkId.Papyrus.LanguageService.csproj
@@ -15,6 +15,8 @@
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0" />
 		<PackageReference Include="System.Collections.Immutable" Version="1.6.0" />
+		<PackageReference Include="System.Interactive.Async" Version="4.1.1" />
+		<PackageReference Include="System.Linq.Async" Version="4.1.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/DarkId.Papyrus.LanguageService/Program/ProgramExtensions.cs
+++ b/src/DarkId.Papyrus.LanguageService/Program/ProgramExtensions.cs
@@ -28,10 +28,10 @@ namespace DarkId.Papyrus.LanguageService.Program
                 {
                     if (!await fileSystem.GetExists(include.Path))
                     {
-                        return null;
+                        return Enumerable.Empty<string>();
                     }
 
-                    return await fileSystem.FindFiles(include.Path, options.FlagsFileName, true);
+                    return await fileSystem.FindFiles(include.Path, options.FlagsFileName, true).ToArrayAsync();
                 })
                 .ToArray());
 
@@ -56,7 +56,7 @@ namespace DarkId.Papyrus.LanguageService.Program
 #else
                         include.Recursive
 #endif
-                    );
+                    ).ToListAsync();
                     return new Tuple<SourceInclude, IEnumerable<string>>(include, files);
                 })
                 .ToArray());

--- a/src/DarkId.Papyrus.LanguageService/Projects/FileSystemXmlProjectLocator.cs
+++ b/src/DarkId.Papyrus.LanguageService/Projects/FileSystemXmlProjectLocator.cs
@@ -22,7 +22,7 @@ namespace DarkId.Papyrus.LanguageService.Projects
         public async Task<IEnumerable<string>> FindProjectFiles(string rootPath)
         {
             _logger.LogInformation($"Searching for Papyrus projects in {rootPath}...");
-            var projectFiles = await _fileSystem.FindFiles(rootPath, "*.ppj", true);
+            var projectFiles = await _fileSystem.FindFiles(rootPath, "*.ppj", true).ToArrayAsync();
             _logger.LogInformation($"Found {projectFiles.Count()} project(s) in {rootPath}:{System.Environment.NewLine}{string.Join(System.Environment.NewLine, projectFiles)}");
 
             return projectFiles;

--- a/src/DarkId.Papyrus.LanguageService/Syntax/InternalSyntax/PropertyHeaderSyntax.cs
+++ b/src/DarkId.Papyrus.LanguageService/Syntax/InternalSyntax/PropertyHeaderSyntax.cs
@@ -12,6 +12,8 @@ namespace DarkId.Papyrus.LanguageService.Syntax.InternalSyntax
             PropertyKeyword = propertyKeyword;
             Identifier = identifier;
             Flags = flags;
+            InitialValue = initialValue;
+            EqualsToken = equalsToken;
         }
 
         public override SyntaxKind Kind => SyntaxKind.PropertyHeader;

--- a/src/DarkId.Papyrus.Server/Features/DocumentAssemblyHandler.cs
+++ b/src/DarkId.Papyrus.Server/Features/DocumentAssemblyHandler.cs
@@ -35,27 +35,27 @@ namespace DarkId.Papyrus.Server.Features
             };
         }
 
-        public Task<DocumentAssembly> Handle(DocumentAssemblyParams request, CancellationToken cancellationToken)
+        public async Task<DocumentAssembly> Handle(DocumentAssemblyParams request, CancellationToken cancellationToken)
         {
             try
             {
                 var scriptFile = _projectManager.GetScriptForFilePath(request.TextDocument.Uri.ToFilePath());
                 if (scriptFile == null)
                 {
-                    return Task.FromResult<DocumentAssembly>(null);
+                    return null;
                 }
 
-                return Task.FromResult(new DocumentAssembly()
+                return new DocumentAssembly()
                 {
                     Assembly = scriptFile.GetScriptAssembly()
-                });
+                };
             }
             catch (Exception e)
             {
                 _logger.LogWarning(e, "Error while handling request.");
             }
 
-            return Task.FromResult<DocumentAssembly>(null);
+            return null;
         }
 
         public void SetCapability(DocumentAssemblyCapability capability)

--- a/src/DarkId.Papyrus.Server/Features/DocumentScriptInfoHandler.cs
+++ b/src/DarkId.Papyrus.Server/Features/DocumentScriptInfoHandler.cs
@@ -35,7 +35,7 @@ namespace DarkId.Papyrus.Server.Features
             };
         }
 
-        public Task<DocumentScriptInfo> Handle(DocumentScriptInfoParams request, CancellationToken cancellationToken)
+        public async Task<DocumentScriptInfo> Handle(DocumentScriptInfoParams request, CancellationToken cancellationToken)
         {
             try
             {
@@ -51,7 +51,7 @@ namespace DarkId.Papyrus.Server.Features
                 var scriptFiles = possibleIdentifiers.SelectMany(identifier =>
                     _projectManager.Projects.Select(p => p.Program.ScriptFiles.GetValueOrDefault(identifier))).WhereNotNull().ToArray();
 
-                return Task.FromResult(new DocumentScriptInfo()
+                return new DocumentScriptInfo()
                 {
                     Identifiers = possibleIdentifiers,
                     IdentifierFiles = scriptFiles.GroupBy(f => f.Id).ToDictionary(k => k.Key.ToString(), k => k.Select(f => f.FilePath).ToList()).ToList().Select(kvp => new IdentifierFiles()
@@ -60,14 +60,14 @@ namespace DarkId.Papyrus.Server.Features
                         Files = kvp.Value
                     }).ToArray(),
                     SearchPaths = searchPaths
-                });
+                };
             }
             catch (Exception e)
             {
                 _logger.LogWarning(e, "Error while handling request.");
             }
 
-            return Task.FromResult<DocumentScriptInfo>(null);
+            return null;
         }
 
         public void SetCapability(DocumentScriptInfoCapability capability)

--- a/src/DarkId.Papyrus.Server/Features/ProjectInfosHandler.cs
+++ b/src/DarkId.Papyrus.Server/Features/ProjectInfosHandler.cs
@@ -26,14 +26,14 @@ namespace DarkId.Papyrus.Server.Features
             _logger = logger;
         }
 
-        public Task<ProjectInfos> Handle(ProjectInfosParams request, CancellationToken cancellationToken)
+        public async Task<ProjectInfos> Handle(ProjectInfosParams request, CancellationToken cancellationToken)
         {
             if (!_projectManager.Projects.Any())
             {
                 _projectManager.UpdateProjects();
             }
 
-            return Task.FromResult(new ProjectInfos()
+            return new ProjectInfos()
             {
                 Projects = new Container<ProjectInfo>(_projectManager.Projects.AsParallel().AsOrdered().Select(p =>
                 {
@@ -63,7 +63,7 @@ namespace DarkId.Papyrus.Server.Features
                         }) : Enumerable.Empty<ProjectInfoSourceInclude>())
                     };
                 }))
-            });
+            };
         }
 
         public void SetCapability(ProjectInfosCapability capability)

--- a/src/DarkId.Papyrus.Server/WorkspaceManager.cs
+++ b/src/DarkId.Papyrus.Server/WorkspaceManager.cs
@@ -48,7 +48,7 @@ namespace DarkId.Papyrus.Server
 
                 if (Path.GetExtension(filePath).CaseInsensitiveEquals(".psc") && _projectManager.Projects.Count() == 0)
                 {
-                    await UpdateProjects(UpdateProjectsOptions.ReloadProjects);
+                    UpdateProjects(UpdateProjectsOptions.ReloadProjects);
                 }
 
                 await _projectManager.PublishDiagnosticsForFilePath(filePath);
@@ -57,17 +57,15 @@ namespace DarkId.Papyrus.Server
             _languageServer.AddHandlers(textProvider);
         }
 
-        private Task UpdateProjects(UpdateProjectsOptions options = UpdateProjectsOptions.None)
+        private void UpdateProjects(UpdateProjectsOptions options = UpdateProjectsOptions.None)
         {
             _projectManager.UpdateProjects(options);
             _languageServer.SendNotification("papyrus/projectsUpdated");
-
-            return Task.FromResult<object>(null);
         }
 
         public async Task<Unit> Handle(DidChangeWorkspaceFoldersParams request, CancellationToken cancellationToken)
         {
-            await UpdateProjects(UpdateProjectsOptions.ReloadProjects);
+            UpdateProjects(UpdateProjectsOptions.ReloadProjects);
             return Unit.Value;
         }
 
@@ -80,7 +78,7 @@ namespace DarkId.Papyrus.Server
         {
             if (Path.GetExtension(request.TextDocument.Uri.ToFilePath()).CaseInsensitiveEquals(".ppj"))
             {
-                await UpdateProjects(UpdateProjectsOptions.ReloadProjects);
+                UpdateProjects(UpdateProjectsOptions.ReloadProjects);
             }
 
             return Unit.Value;
@@ -107,11 +105,11 @@ namespace DarkId.Papyrus.Server
 
             if (createdOrDeleted.Any(c => Path.GetExtension(c.Uri.ToFilePath()).CaseInsensitiveEquals(".psc")))
             {
-                await UpdateProjects(UpdateProjectsOptions.ReloadProjects);
+                UpdateProjects(UpdateProjectsOptions.ReloadProjects);
             }
             else if (createdOrDeleted.Any(c => Path.GetExtension(c.Uri.ToFilePath()).CaseInsensitiveEquals(".psc")))
             {
-                await UpdateProjects(UpdateProjectsOptions.ResolveExistingProjectSources);
+                UpdateProjects(UpdateProjectsOptions.ResolveExistingProjectSources);
             }
 
             return Unit.Value;


### PR DESCRIPTION
Some various small refactors that I extracted while doing the sweeping nullability refactor.
- PropertyHeaderSyntax I noticed the ctor parameters weren't setting the class members
- DictionaryExtensions.SynchronizeWithFactory utilizes TryGet patterns to minimize queries on the dictionary.  Also, preDisposalHandler was not being called.
- Some JSON parsing refactored to TryGet patterns.  Again, less queries, but also works better with the incoming nullability features as the tryget results are guaranteed to not be null.
- IAsyncEnumerable usage instead of `Task<IEnumerable<T>>`

Just a small guy to get things rolling.  I did -not- test any of this.  I'm currently unaware of the proper testing procedures, so I wasn't sure what to be checking.   However, sounds like it's being merged into a heavily experimental branch anyway, so might not matter.