### PR TITLE
Feat: Support variables node in papyrus projects

### DIFF
--- a/src/DarkId.Papyrus.LanguageService/Projects/PapyrusProject.cs
+++ b/src/DarkId.Papyrus.LanguageService/Projects/PapyrusProject.cs
@@ -16,6 +16,8 @@ namespace DarkId.Papyrus.LanguageService.Projects
 
         private string[] scriptsField;
 
+        private Variable[] variablesField;
+
         private string outputField;
 
         private string flagsField;
@@ -75,6 +77,19 @@ namespace DarkId.Papyrus.LanguageService.Projects
             set
             {
                 this.scriptsField = value;
+            }
+        }
+
+        [System.Xml.Serialization.XmlArrayItemAttribute("Variable")]
+        public Variable[] Variables
+        {
+            get
+            {
+                return this.variablesField;
+            }
+            set
+            {
+                this.variablesField = value;
             }
         }
 
@@ -217,6 +232,44 @@ namespace DarkId.Papyrus.LanguageService.Projects
                 this.finalFieldSpecified = value;
             }
         }
+
+        public void ExpandVariables()
+        {
+            if (Variables?.Length <= 0)
+            {
+                return;
+            }
+
+            foreach (var variable in Variables)
+            {
+                var name = "@" + variable.Name;
+                Output = Output.Replace(name, variable.Value);
+
+                if (Imports?.Length > 0)
+                {
+                    for (var i = 0; i < Imports.Length; i++)
+                    {
+                        Imports[i] = Imports[i].Replace(name, variable.Value);
+                    }
+                }
+
+                if (Scripts?.Length > 0)
+                {
+                    for (var i = 0; i < Scripts.Length; i++)
+                    {
+                        Scripts[i] = Scripts[i].Replace(name, variable.Value);
+                    }
+                }
+
+                if (Folders?.Length > 0)
+                {
+                    for (var i = 0; i < Folders.Length; i++)
+                    {
+                        Folders[i].Value = Folders[i].Value.Replace(name, variable.Value);
+                    }
+                }
+            }
+        }
     }
 
     /// <remarks/>
@@ -264,6 +317,45 @@ namespace DarkId.Papyrus.LanguageService.Projects
 
         /// <remarks/>
         [System.Xml.Serialization.XmlTextAttribute()]
+        public string Value
+        {
+            get
+            {
+                return this.valueField;
+            }
+            set
+            {
+                this.valueField = value;
+            }
+        }
+    }
+
+    /// <remarks/>
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("xsd", "0.0.0.0")]
+    [System.SerializableAttribute()]
+    [System.Diagnostics.DebuggerStepThroughAttribute()]
+    [System.ComponentModel.DesignerCategoryAttribute("code")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "PapyrusProject.xsd")]
+    public class Variable
+    {
+        private string nameField;
+
+        private string valueField;
+
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        public string Name
+        {
+            get
+            {
+                return this.nameField;
+            }
+            set
+            {
+                this.nameField = value;
+            }
+        }
+
+        [System.Xml.Serialization.XmlAttributeAttribute()]
         public string Value
         {
             get

--- a/src/DarkId.Papyrus.LanguageService/Projects/XmlProjectDeserializer.cs
+++ b/src/DarkId.Papyrus.LanguageService/Projects/XmlProjectDeserializer.cs
@@ -1,5 +1,4 @@
 using System.IO;
-using System.Threading.Tasks;
 using System.Xml.Serialization;
 
 namespace DarkId.Papyrus.LanguageService.Projects
@@ -12,6 +11,7 @@ namespace DarkId.Papyrus.LanguageService.Projects
             {
                 var serializer = new XmlSerializer(typeof(PapyrusProject));
                 var project = (PapyrusProject)serializer.Deserialize(sr);
+                project.ExpandVariables();
 
                 return project;
             }


### PR DESCRIPTION
Implements support for the `Variables` node that [pyro adds to PPJs](https://wiki.fireundubh.com/pyro#variables).

The main use-case for this on the extension side is probably using them in `Imports`.

Checklist before doing the merge commit:
- [ ] Review code in PR
- [ ] Testing
- [ ] Check format of title for CI (make sure it has valid `<type>: <subject>` format)
- [ ] **Use Squash and Commit**