### PR TITLE
feat: More grammar fixes

### DIFF
--- a/src/papyrus-lang-vscode/CHANGELOG.md
+++ b/src/papyrus-lang-vscode/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [2.22.1](https://github.com/joelday/papyrus-lang/compare/v2.22.0...v2.22.1) (2020-08-09)
+
+
+### Bug Fixes
+
+* NullReferenceException when parsing .ppj files. Incorrect resolution of .ppj variable substitutions. ([db68595](https://github.com/joelday/papyrus-lang/commit/db6859571dfe3b2257c1c79cb73b47bf7e728813))
+* Parsing exception related to Windows globalization settings. ([#133](https://github.com/joelday/papyrus-lang/issues/133)) ([bd15498](https://github.com/joelday/papyrus-lang/commit/bd15498ad46c8f33fad8069052326f3be38e2b35))
+
 # [2.22.0](https://github.com/joelday/papyrus-lang/compare/v2.21.2...v2.22.0) (2020-08-07)
 
 

--- a/src/papyrus-lang-vscode/syntaxes/papyrus/papyrus.json
+++ b/src/papyrus-lang-vscode/syntaxes/papyrus/papyrus.json
@@ -429,6 +429,10 @@
             {
               "match": "\\=",
               "name": "keyword.operator.assignment.papyrus"
+            },
+            {
+              "match": "(?i)\\b(const|conditional|hidden)\\b",
+              "name": "keyword.language.variable-flag.papyrus"
             }
           ]
         }

--- a/src/papyrus-lang-vscode/syntaxes/papyrus/papyrus.json
+++ b/src/papyrus-lang-vscode/syntaxes/papyrus/papyrus.json
@@ -11,13 +11,7 @@
       "include": "#quoted-string"
     },
     {
-      "begin": ";/",
-      "end": "/;",
-      "name": "comment.block.papyrus"
-    },
-    {
-      "match": "(;).*$\\n?",
-      "name": "comment.line.semicolon.papyrus"
+      "include": "#comment"
     },
     {
       "begin": "{",
@@ -44,8 +38,7 @@
       "name": "meta.scriptname-declaration.papyrus",
       "patterns": [
         {
-          "match": ";([^\\n]*)",
-          "name": "comment.line.semicolon.papyrus"
+          "include": "#comment"
         },
         {
           "match": "(?i)(conditional|default|hidden|native|const)",
@@ -76,8 +69,7 @@
           "include": "#quoted-string"
         },
         {
-          "match": ";([^\\n]*)",
-          "name": "comment.line.semicolon.papyrus"
+          "include": "#comment"
         },
         {
           "match": "(?i)\\b(auto|autoreadonly|const|conditional|mandatory|hidden)\\b",
@@ -247,6 +239,19 @@
         }
       ]
     },
+    "comment": {
+      "patterns": [
+        {
+          "match": ";[^\\n]*",
+          "name": "comment.line.semicolon.papyrus"
+        },
+        {
+          "begin": ";/",
+          "end": "/;",
+          "name": "comment.block.papyrus"
+        }
+      ]
+    },
     "cast-expression": {
       "patterns": [
         {
@@ -410,6 +415,9 @@
               "include": "#cast-expression"
             },
             {
+              "include": "#comment"
+            },
+            {
               "include": "#constants"
             },
             {
@@ -425,7 +433,7 @@
         },
         {
           "comment": "Variable declaration without a default value",
-          "begin": "(?i)^\\s*(?!if|else|elseif|endif|while|endwhile|return)([_a-z][0-9_a-z]*)(?:\\[\\])?\\s+([_a-z][0-9_a-z]*)(?:\\s+(conditional)\b)?$",
+          "begin": "(?i)^\\s*(?!if|else|elseif|endif|while|endwhile|return)([_a-z][0-9_a-z]*)(?:\\[\\])?\\s+([_a-z][0-9_a-z]*)(?:\\s+(conditional)\b)?",
           "beginCaptures": {
             "1": {
               "name": "storage.type.papyrus"
@@ -435,7 +443,12 @@
             }
           },
           "end": "([\\n\\r])",
-          "name": "meta.variable.papyrus"
+          "name": "meta.variable.papyrus",
+          "patterns": [
+            {
+              "include": "#comment"
+            }
+          ]
         }
       ]
     }

--- a/src/papyrus-lang-vscode/syntaxes/papyrus/papyrus.json
+++ b/src/papyrus-lang-vscode/syntaxes/papyrus/papyrus.json
@@ -362,8 +362,8 @@
       ]
     },
     "quoted-string": {
-      "begin": "\"",
-      "end": "\"",
+      "begin": "(?<!\\\\)\"",
+      "end": "(?<!\\\\)\"",
       "name": "string.quoted.double.papyrus"
     },
     "params": {

--- a/src/papyrus-lang-vscode/syntaxes/papyrus/papyrus.json
+++ b/src/papyrus-lang-vscode/syntaxes/papyrus/papyrus.json
@@ -392,8 +392,8 @@
     "variable": {
       "patterns": [
         {
-          "comment": "Variable declaration with a default value",
-          "begin": "(?i)^\\s*([_a-z][0-9_a-z]*)(?:\\[\\])?\\s+([_a-z][0-9_a-z]*)(?:\\s*(\\=)(?!\\=))",
+          "comment": "Variable declaration",
+          "begin": "(?i)^\\s*(?!if|else|elseif|endif|while|endwhile|return)([_a-z][0-9_a-z]*)(?:\\[\\])?\\s+([_a-z][0-9_a-z]*)",
           "beginCaptures": {
             "1": {
               "name": "storage.type.papyrus"
@@ -425,25 +425,10 @@
             },
             {
               "include": "#quoted-string"
-            }
-          ]
-        },
-        {
-          "comment": "Variable declaration without a default value",
-          "begin": "(?i)^\\s*(?!if|else|elseif|endif|while|endwhile|return)([_a-z][0-9_a-z]*)(?:\\[\\])?\\s+([_a-z][0-9_a-z]*)(?:\\s+(conditional)\b)?",
-          "beginCaptures": {
-            "1": {
-              "name": "storage.type.papyrus"
             },
-            "2": {
-              "name": "variable.other.papyrus"
-            }
-          },
-          "end": "([\\n\\r])",
-          "name": "meta.variable.papyrus",
-          "patterns": [
             {
-              "include": "#comment"
+              "match": "\\=",
+              "name": "keyword.operator.assignment.papyrus"
             }
           ]
         }

--- a/src/papyrus-lang-vscode/syntaxes/papyrus/papyrus.json
+++ b/src/papyrus-lang-vscode/syntaxes/papyrus/papyrus.json
@@ -82,27 +82,6 @@
       ]
     },
     {
-      "begin": "(?i)\\b(?:([_a-z][0-9_a-z]+)\\s+)?(function|event)\\s+([^\\(]*)\\(",
-      "beginCaptures": {
-        "1": {
-          "name": "storage.type.papyrus"
-        },
-        "2": {
-          "name": "keyword.control.functionstart.papyrus"
-        },
-        "3": {
-          "name": "entity.name.function.papyrus"
-        }
-      },
-      "end": "\\)",
-      "name": "meta.function.papyrus",
-      "patterns": [
-        {
-          "include": "#params"
-        }
-      ]
-    },
-    {
       "match": "(?i)\\b(auto\\s+)?(state)\\s+(.*)\\n",
       "name": "meta.state.papyrus",
       "captures": {
@@ -204,25 +183,22 @@
       "name": "keyword.control.propertyend.papyrus"
     },
     {
+      "include": "#function-declaration"
+    },
+    {
+      "include": "#variable"
+    },
+    {
       "include": "#base-types"
     },
     {
       "include": "#cast-expression"
     },
     {
-      "include": "#class-types"
-    },
-    {
-      "include": "#builtin-funcs"
-    },
-    {
       "include": "#function-call"
     },
     {
       "include": "#new-expression"
-    },
-    {
-      "include": "#variable"
     }
   ],
   "repository": {
@@ -345,6 +321,27 @@
         },
         {
           "include": "#quoted-string"
+        }
+      ]
+    },
+    "function-declaration": {
+      "begin": "(?i)\\s*\\b(?:([_a-z][0-9_a-z]+)(?:\\[\\])?\\s+)?(function|event)\\s+([^\\(]*)\\(",
+      "beginCaptures": {
+        "1": {
+          "name": "storage.type.papyrus"
+        },
+        "2": {
+          "name": "keyword.control.functionstart.papyrus"
+        },
+        "3": {
+          "name": "entity.name.function.papyrus"
+        }
+      },
+      "end": "\\)",
+      "name": "meta.function.papyrus",
+      "patterns": [
+        {
+          "include": "#params"
         }
       ]
     },


### PR DESCRIPTION
Another batch of grammar fixes/additions:
* Fixes variable declarations not working for base types (I didn't notice breaking this because my theme doesn't highlight variable names)
* Comments after variable declarations are correctly displayed
* Escaped quotes don't break strings anymore
* Variable flags (const, conditional, hidden) are now recognized

I'm pretty sure this is as good as the syntax highlighting can get using TextMate grammars.

I tried adding highlighting for all uses of the default scripts in FO4/Skyrim (Actor/Game/Race etc.) no matter where they are used in the code, but that caused a ton of issues with property/variable declarations among other things.
The only way to make this work would be to implement [Semantic Highlighting support](https://github.com/microsoft/vscode/wiki/Semantic-Highlighting-Overview) which was added to VSCode in v1.43.

#### Additional context

<details>
<summary>Some before/after examples</summary>

Variables before
![Variables_Before](https://user-images.githubusercontent.com/9725089/89767135-98978480-daf9-11ea-8bfe-c6c97ae741d6.png)
Variables after
![Variables_After](https://user-images.githubusercontent.com/9725089/89767141-9cc3a200-daf9-11ea-88af-4584dabfa566.png)
Strings before
![String_Before](https://user-images.githubusercontent.com/9725089/89767149-a0572900-daf9-11ea-91fc-80e2cbfd12c2.png)
Strings after
![String_After](https://user-images.githubusercontent.com/9725089/89767158-a3521980-daf9-11ea-9fb4-276226856573.png)
</details>

Checklist before doing the merge commit:
- [ ] Review code in PR
- [ ] Testing
- [ ] Check format of title for CI (make sure it has valid `<type>: <subject>` format)
- [ ] **Use Squash and Commit**