### PR TITLE
Indent level support added for while/endwhile

### DIFF
--- a/src/papyrus-lang-vscode/src/features/LanguageConfigurations.ts
+++ b/src/papyrus-lang-vscode/src/features/LanguageConfigurations.ts
@@ -12,8 +12,8 @@ export class LanguageConfigurations {
             },
             brackets: [['{', '}'], ['[', ']'], ['(', ')']],
             indentationRules: {
-                increaseIndentPattern: /^\s*(if|(\S+\s+)?(property\W+\w+(?!.*(auto)))|struct|group|state|event|(\S+\s+)?(function.*\(.*\)(?!.*native))|else|elseif)/i,
-                decreaseIndentPattern: /^\s*(endif|endproperty|endstruct|endgroup|endstate|endevent|endfunction|else|elseif)/i,
+                increaseIndentPattern: /^\s*(if|while|(\S+\s+)?(property\W+\w+(?!.*(auto)))|struct|group|state|event|(\S+\s+)?(function.*\(.*\)(?!.*native))|else|elseif)/i,
+                decreaseIndentPattern: /^\s*(endif|endwhile|endproperty|endstruct|endgroup|endstate|endevent|endfunction|else|elseif)/i,
             },
         });
     }

--- a/src/papyrus-lang-vscode/syntaxes/papyrus/papyrus.tmLanguage
+++ b/src/papyrus-lang-vscode/syntaxes/papyrus/papyrus.tmLanguage
@@ -11,9 +11,9 @@
     <key>firstLineMatch</key>
     <string>(?i)^scriptname</string>
     <key>foldingStartMarker</key>
-    <string>(?i)^\s*(if|property|struct|group|state|event|(\S+\s+)?function)</string>
+    <string>(?i)^\s*(if|while|property|struct|group|state|event|(\S+\s+)?function)</string>
     <key>foldingStopMarker</key>
-    <string>(?i)^\s*(endif|endproperty|endstruct|endgroup|endstate|endevent|endfunction)</string>
+    <string>(?i)^\s*(endif|endwhile|endproperty|endstruct|endgroup|endstate|endevent|endfunction)</string>
     <key>name</key>
     <string>papyrus</string>
     <key>patterns</key>


### PR DESCRIPTION
New feature #indent added: `while` `endwhile` will now indent like `if` `endif`.

Testing: Not.. sure how much it needs tbh. Edited VS Markplace's cached extension directly.. working as expected.

Checklist before doing the merge commit:
- [ ] Review code in PR
- [ ] Testing
- [ ] Check format of title for CI (make sure it has valid `<type>: <subject>` format)
- [ ] **Use Squash and Commit**