### PR TITLE
feat: Support Multi-Line and String Escapes

### DIFF
--- a/src/papyrus-lang-vscode/syntaxes/papyrus/papyrus.tmLanguage
+++ b/src/papyrus-lang-vscode/syntaxes/papyrus/papyrus.tmLanguage
@@ -84,7 +84,7 @@
                 </dict>
                 <dict>
                     <key>match</key>
-                    <string>(?i)(conditional|default|hidden|native|const)</string>
+                    <string>(?i)(?:\s+|(?&lt;=/;))(conditional|default|hidden|native|const)(?=\s|;|$)</string>
                     <key>name</key>
                     <string>keyword.language.script-flag.papyrus</string>
                 </dict>
@@ -335,6 +335,10 @@
             <key>include</key>
             <string>#builtin-funcs</string>
         </dict>
+        <dict>
+            <key>include</key>
+            <string>#newline-escape</string>
+        </dict>
     </array>
     <key>repository</key>
     <dict>
@@ -371,12 +375,33 @@
         </dict>
         <key>quoted-string</key>
         <dict>
+            <key>name</key>
+            <string>string.quoted.double.papyrus</string>
             <key>begin</key>
             <string>&quot;</string>
             <key>end</key>
-            <string>&quot;</string>
+            <string>[&quot;\n]</string>
+            <key>patterns</key>
+            <array>
+              <dict>
+                <key>include</key>
+                <string>#string-character-escape</string>
+              </dict>
+            </array>
+        </dict>
+        <key>string-character-escape</key>
+        <dict>
             <key>name</key>
-            <string>string.quoted.double.papyrus</string>
+            <string>constant.character.escape.papyrus</string>
+            <key>match</key>
+            <string>\\[nt\\&quot;]?</string>
+        </dict>
+        <key>newline-escape</key>
+        <dict>
+            <key>match</key>
+            <string>\\(?=\s*\n)</string>
+            <key>name</key>
+            <string>constant.character.escape.papyrus</string>
         </dict>
         <key>params</key>
         <dict>
@@ -413,6 +438,10 @@
                     </dict>
                     <key>name</key>
                     <string>meta.parameter.papyrus</string>
+                </dict>
+                <dict>
+                    <key>include</key>
+                    <string>#newline-escape</string>
                 </dict>
                 <dict>
                     <key>match</key>

--- a/src/papyrus-lang-vscode/syntaxes/papyrus/papyrus.tmLanguage
+++ b/src/papyrus-lang-vscode/syntaxes/papyrus/papyrus.tmLanguage
@@ -403,8 +403,125 @@
             <key>name</key>
             <string>constant.character.escape.papyrus</string>
         </dict>
-        <key>params</key>
+        <key>parameter-start-comma</key>
         <dict>
+            <key>match</key>
+            <string>,\s*([\w\[\]:]+)\s+(\w+)\b(?:\s*(=))?</string>
+            <key>captures</key>
+            <dict>
+                <key>1</key>
+                <dict>
+                    <key>name</key>
+                    <string>storage.type.variable.papyrus</string>
+                </dict>
+                <key>2</key>
+                <dict>
+                    <key>name</key>
+                    <string>variable.parameter.papyrus</string>
+                </dict>
+                <key>3</key>
+                <dict>
+                    <key>name</key>
+                    <string>keyword.operator.assignment.papyrus</string>
+                </dict>
+            </dict>
+            <key>name</key>
+            <string>meta.parameter.papyrus</string>
+        </dict>
+        <key>parameter-start-pattern</key>
+        <dict>
+            <key>match</key>
+            <string>\G\s*([\w\[\]:]+)\s+(\w+)\b(?:\s*(=))?</string>
+            <key>captures</key>
+            <dict>
+                <key>1</key>
+                <dict>
+                    <key>name</key>
+                    <string>storage.type.variable.papyrus</string>
+                </dict>
+                <key>2</key>
+                <dict>
+                    <key>name</key>
+                    <string>variable.parameter.papyrus</string>
+                </dict>
+                <key>3</key>
+                <dict>
+                    <key>name</key>
+                    <string>keyword.operator.assignment.papyrus</string>
+                </dict>
+            </dict>
+            <key>name</key>
+            <string>meta.parameter.papyrus</string>
+        </dict>
+        <key>parameter-comma-at-start</key>
+        <dict>
+            <key>match</key>
+            <string>\G\s*,</string>
+            <key>name</key>
+            <string>invalid.illegal.function.papyrus</string>
+        </dict>
+        <key>parameter-newline-escape-with-comma</key>
+        <dict>
+            <key>begin</key>
+            <string>,\s*(\\)\s*\n</string>
+            <key>beginCaptures</key>
+            <dict>
+                <key>1</key>
+                <dict>
+                    <key>name</key>
+                    <string>constant.character.escape.papyrus</string>
+                </dict>
+            </dict>
+            <key>end</key>
+            <string>\n|(?=,\s*\\|\\|\))</string>
+            <key>name</key>
+            <string>meta.function.escapedline.comma.papyrus</string>
+            <key>patterns</key>
+            <array>
+                <dict>
+                    <key>include</key>
+                    <string>#parameter-comma-at-start</string>
+                </dict>
+                <dict>
+                    <key>include</key>
+                    <string>#constants</string>
+                </dict>
+                <dict>
+                    <key>include</key>
+                    <string>#quoted-string</string>
+                </dict>
+                <dict>
+                    <key>include</key>
+                    <string>#parameter-start-comma</string>
+                </dict>
+                <dict>
+                    <key>include</key>
+                    <string>#parameter-start-pattern</string>
+                </dict>
+                <dict>
+                    <key>match</key>
+                    <string>[^\s\)]+</string>
+                    <key>name</key>
+                    <string>invalid.illegal.function.papyrus</string>
+                </dict>
+            </array>
+        </dict>
+        <key>parameter-newline-escape-without-comma</key>
+        <dict>
+            <key>begin</key>
+            <string>(\\)\s*\n</string>
+            <key>beginCaptures</key>
+            <dict>
+                <key>1</key>
+                <dict>
+                    <key>name</key>
+                    <string>constant.character.escape.papyrus</string>
+                </dict>
+            </dict>
+            <key>end</key>
+            <string>\n|(?=,\s*\\|\\|\))</string>
+            <key>name</key>
+            <string>meta.function.escapedline.nocomma.papyrus</string>
             <key>patterns</key>
             <array>
                 <dict>
@@ -416,36 +533,52 @@
                     <string>#quoted-string</string>
                 </dict>
                 <dict>
+                    <key>include</key>
+                    <string>#parameter-start-comma</string>
+                </dict>
+                <dict>
                     <key>match</key>
-                    <string>(?:\G\s*|,\s*)([\w\[\]:]+)\s+(\w+)\b(?:\s*(=))?</string>
-                    <key>captures</key>
-                    <dict>
-                        <key>1</key>
-                        <dict>
-                            <key>name</key>
-                            <string>storage.type.variable.papyrus</string>
-                        </dict>
-                        <key>2</key>
-                        <dict>
-                            <key>name</key>
-                            <string>variable.parameter.papyrus</string>
-                        </dict>
-                        <key>3</key>
-                        <dict>
-                            <key>name</key>
-                            <string>keyword.operator.assignment.papyrus</string>
-                        </dict>
-                    </dict>
+                    <string>[^\s\)]+</string>
                     <key>name</key>
-                    <string>meta.parameter.papyrus</string>
+                    <string>invalid.illegal.function.papyrus</string>
+                </dict>
+            </array>
+        </dict>
+        <key>params</key>
+        <dict>
+            <key>patterns</key>
+            <array>
+                <dict>
+                    <key>include</key>
+                    <string>#parameter-comma-at-start</string>
                 </dict>
                 <dict>
                     <key>include</key>
-                    <string>#newline-escape</string>
+                    <string>#constants</string>
+                </dict>
+                <dict>
+                    <key>include</key>
+                    <string>#quoted-string</string>
+                </dict>
+                <dict>
+                    <key>include</key>
+                    <string>#parameter-start-comma</string>
+                </dict>
+                <dict>
+                    <key>include</key>
+                    <string>#parameter-start-pattern</string>
+                </dict>
+                <dict>
+                    <key>include</key>
+                    <string>#parameter-newline-escape-with-comma</string>
+                </dict>
+                <dict>
+                    <key>include</key>
+                    <string>#parameter-newline-escape-without-comma</string>
                 </dict>
                 <dict>
                     <key>match</key>
-                    <string>[^\s\)]+?</string>
+                    <string>^.+|[^\s\)]+?</string>
                     <key>name</key>
                     <string>invalid.illegal.function.papyrus</string>
                 </dict>


### PR DESCRIPTION
The Papyrus compiler supports escaping in, as far as I know, three contexts:

* Within a string. The following are valid:
  | Escape | Resulting Character |
  | :-: | :-: |
  | `\n` | New Line |
  | `\t` | Tab Character |
  | `\"` | `"` |
  | `\\` | `\` |
* At the end of a line. For example:
  ```papyrus
  event onInit()
      Game.GetPlayer() \
          .Kill()
  endEvent
  ```
* Within parameter lists. *While this falls into the previous by definition, the syntax highlighting method does not.*
  Example:
  ```papyrus
  function testingFunction(\
      , Form akForm1, Location akLoc1, Form akForm2, \
        Form akForm3, Location akLoc2, Form akForm4 \
      , Form akForm5, Location akLoc3, Form akForm6 \
      , Form akForm7, Location akLoc4, Form akForm8 \
  )
  endFunction
  ```

This pull request addresses all three of these cases within the Papyrus grammar.