### PR TITLE
fix: endproperty and scriptname syntax color (#151)

### DIFF
--- a/src/papyrus-lang-vscode/syntaxes/papyrus/papyrus.tmLanguage
+++ b/src/papyrus-lang-vscode/syntaxes/papyrus/papyrus.tmLanguage
@@ -52,7 +52,7 @@
                 <key>1</key>
                 <dict>
                     <key>name</key>
-                    <string>support.type.other.scriptname-declaration.papyrus</string>
+                    <string>keyword.language.scriptname-declaration.papyrus</string>
                 </dict>
                 <key>2</key>
                 <dict>
@@ -321,7 +321,7 @@
             <key>match</key>
             <string>(?i)\b(endproperty)\b</string>
             <key>name</key>
-            <string>keyword.control.propertyend.papyrus</string>
+            <string>keyword.other.property.propertyend.papyrus</string>
         </dict>
         <dict>
             <key>include</key>


### PR DESCRIPTION
<img width="219" alt="image" src="https://github.com/joelday/papyrus-lang/assets/12450333/5700ecf2-ec5d-497c-ba61-36237f3056d3">

And as a bonus

<img width="204" alt="image" src="https://github.com/joelday/papyrus-lang/assets/12450333/f4b9f7e2-b13f-449c-9cd7-625149fcdd62">

Close #151 
