### PR TITLE
Fix for incorrect files being opened is vscode when running server in…

### DIFF
--- a/src/DarkId.Papyrus.Common/PathUtilities.cs
+++ b/src/DarkId.Papyrus.Common/PathUtilities.cs
@@ -75,6 +75,10 @@ namespace DarkId.Papyrus.Common
             {
                 uri.Insert(0, "file:");
             }
+            else if (uri.Length >= 2 && uri[0] == '/' && uri[1] != '/' && Type.GetType("Mono.Runtime") != null)
+            {
+                uri.Insert(0, "file://");
+            }
             else if (uri.Length >= 2 && uri[0] == '/' && uri[1] != '/')
             {
                 uri.Insert(0, "file:/");


### PR DESCRIPTION
… mono

When running the papyrus-lang dotnet server in mono, it appears there is an incompatibility where it will mangle the file:/ descriptor. It will add the mountpoint to the beginning of the uri, which obviously will break the editor as it will try to open a non-existent file. Add a guard against that code block when running in mono, to instead use the working file:///, which appears to work in mono and vscode running under linux.

(Make sure the title has the format `<type>: <subject>` where type is one of: feat, fix, docs, style, refactor, perf, test, or chore. Example: "fix: kill nasty bug". Then delete this paragraph.)
